### PR TITLE
Tagging:init ignores Settings

### DIFF
--- a/tagging.js
+++ b/tagging.js
@@ -394,7 +394,7 @@
             self = this;
 
             // Getting all data Parameters to fully customize the single tag box selecteds
-            self.config = $.extend( {}, self.defaults, self.options, self.getDataOptions() );
+            self.config = $.extend( {}, self.defaults, self.options );
 
             // Pre-existent text
             init_text = self.$elem.text();


### PR DESCRIPTION
I found an error when creating a new instance with options:
`$('#tagging').tagging({"tags-input-name": "foo"});`
The value are available in the `self.options` Object -  but they are overwritten by `self.getDataOptions()` with the default value.
To avoid this error i removed `self.getDataOptions()` call