### PR TITLE
An option for getting rid of a duplicate tag char typed by the user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ a little description and the default value:
 | **pre-tags-separator** | `String` | `", "` | This is used to `split` the initial text and add `preexistint-tag`. By default, you must put new tags using a comma and a space (`", "`). |
 | **tag-box-class** | `String` | `"tagging"` | Class of the tag box. |
 | **tag-char** | `String` | `"#"` | Single Tag char. |
+| **no-duplicate-tag-char** | `String` | `"#"` | True to remove a tag char typed by the user. |
 | **tag-class** | `String` | `"tag"` | Single Tag class. |
 | **tag-on-blur** | `Boolean` | `true` | If `true`, clicking away from the `$type_zone` will add a new tag. |
 | **tags-input-name** | `String` | `"tag"` | Name to use as `name=""` in single tags' input. By default, all tags being passed as array like `tag[]`. |

--- a/tagging.js
+++ b/tagging.js
@@ -81,6 +81,7 @@
             "pre-tags-separator": ", ",                     // By default, you must put new tags using a new line
             "tag-box-class": "tagging",                     // Class of the tag box
             "tag-char": "#",                                // Single Tag char
+            "no-duplicate-tag-char": false,                 // True to remove a tag char typed by the user
             "tag-class": "tag",                             // Single Tag class
             "tags-input-name": "tag",                       // Name to use as name="" in single tags (by default tag[])
             "tag-on-blur": true,                            // Add the current tag if user clicks away from type-zone
@@ -129,6 +130,11 @@
             // If case-sensitive is true, write everything in lowercase
             if ( ! self.config[ "case-sensitive" ] ) {
                 text = text.toLowerCase();
+            }
+
+            // If tag-char already given remove it
+            if ( self.config[ "no-duplicate-tag-char" ] && text.charAt(0) === self.config[ "tag-char" ] ) {
+                text = text.substring(1);
             }
 
             // Checking if text is a Forbidden Word


### PR DESCRIPTION
The problem:
If the user types for example '#hashtag'
The resulting tag will be [#]'#hashtag'

The solution:
An option for getting rid of a duplicate tag char typed by the user.
With the new 'no-duplicate-tag-char' -option enabled the result will be: [#]'hashtag'