### PR TITLE
An option to limit the number of tags that can be added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,10 +307,12 @@ a little description and the default value:
 | **no-spacebar** | `Boolean` | `false` | Spacebar key add a new tag by default. `true` to avoid that.|
 | **pre-tags-separator** | `String` | `", "` | This is used to `split` the initial text and add `preexistint-tag`. By default, you must put new tags using a comma and a space (`", "`). |
 | **tag-box-class** | `String` | `"tagging"` | Class of the tag box. |
+| **tag-box-editable-class** | `String` | `"editable"` | Class of the tag box when editable, used together with tags-limit option for css targeting. |
 | **tag-char** | `String` | `"#"` | Single Tag char. |
 | **tag-class** | `String` | `"tag"` | Single Tag class. |
 | **tag-on-blur** | `Boolean` | `true` | If `true`, clicking away from the `$type_zone` will add a new tag. |
 | **tags-input-name** | `String` | `"tag"` | Name to use as `name=""` in single tags' input. By default, all tags being passed as array like `tag[]`. |
+| **tags-limit** | `Integer` | `0` | Limit the number of tags that can be added, zero for no limit. |
 | **type-zone-class** | `String` | `"type-zone"` | Class of the type-zone. |
 
 ## Available Methods ##

--- a/example/tag-basic-style.css
+++ b/example/tag-basic-style.css
@@ -1,10 +1,13 @@
 /* Tagging Basic Style */
 .tagging {
 	border: 1px solid #CCCCCC;
-	cursor: text;
 	font-size: 1em;
 	height: auto;
 	padding: 10px 10px 15px;
+}
+
+.tagging.editable {
+	cursor: text;
 }
 
 .tag {

--- a/tagging.js
+++ b/tagging.js
@@ -80,10 +80,12 @@
             "no-spacebar": false,                           // Spacebar key add a new tag by default, true to avoid that
             "pre-tags-separator": ", ",                     // By default, you must put new tags using a new line
             "tag-box-class": "tagging",                     // Class of the tag box
+            "tag-box-editable-class": "editable",           // Class of the tag box when editable, used together with tags-limit option for css targeting
             "tag-char": "#",                                // Single Tag char
             "tag-class": "tag",                             // Single Tag class
             "tags-input-name": "tag",                       // Name to use as name="" in single tags (by default tag[])
             "tag-on-blur": true,                            // Add the current tag if user clicks away from type-zone
+            "tags-limit": 0,                                // Limit the number of tags that can be added, zero means no limit
             "type-zone-class": "type-zone",                 // Class of the type-zone
         },
 
@@ -210,6 +212,16 @@
 
             // Adding tag in the type zone
             self.$type_zone.before( $tag );
+
+            // Hide the type zone if we already have a maximum number of tags
+            if ( self.config[ "tags-limit" ] > 0 && self.tags.length >= self.config[ "tags-limit" ] ) {
+
+                // Remove editable class for css targeting
+                self.$elem.removeClass( self.config[ "tag-box-editable-class" ] );
+
+                // Hide the type zone
+                self.$type_zone.hide();
+            }
 
             return true;
         },
@@ -407,9 +419,10 @@
                              .addClass( self.config[ "type-zone-class" ] )
                              .attr( "contenteditable", true );
 
-            // Adding tagging class and appending the type zone
+            // Adding tagging and editable class and appending the type zone
             self.$elem
                 .addClass( self.config[ "tag-box-class" ] )
+                .addClass( self.config[ "tag-box-editable-class" ] )
                 .append( self.$type_zone );
 
             // Keydown event listener on tag box type_zone
@@ -641,6 +654,16 @@
 
                 // Set the new text
                 self.valInput( $tag.pure_text );
+            }
+
+            // Show the type zone if we no longer have a maximum number of tags
+            if ( self.config[ "tags-limit" ] > 0 && self.$type_zone.not(":visible") && self.tags.length < self.config[ "tags-limit" ] ) {
+
+                // Add editable class for css targeting
+                self.$elem.addClass( self.config[ "tag-box-editable-class" ] );
+
+                // Show the type zone
+                self.$type_zone.show();
             }
 
             return $tag;


### PR DESCRIPTION
The number of tags that can be added can now be limited with the 'tags-limit' option. Default value is zero which equals to no limit.

Also added an option 'tag-box-editable-class' which defines the name of the class that will be added to the tag box when new tags can be added. This can be used with css to for example to show the text-cursor when the tag box can be edited and to show a normal cursor otherwise.
