### PR TITLE
Wrap text value in escaped quotes to allow for spaces in tags.

### DIFF
--- a/tagging.js
+++ b/tagging.js
@@ -442,7 +442,7 @@
 
                 // The pressed key
                 //pressed_key     = e.which;
-				pressed_key     = e.key;
+                pressed_key     = e.key;
                 //console.log( pressed_key );
 
                 // For in loop to look to Remove Keys
@@ -614,7 +614,7 @@
                 text = $tag;
 
                 // Retrieving the $_obj of the tag
-                $tag = self.$elem.find( "input[value=" + text + "]" ).parent();
+                $tag = self.$elem.find( "input[value=\"" + text + "\"]" ).parent();
 
                 // If nothing is found, return an error
                 if ( ! $tag.length ) {


### PR DESCRIPTION
Anytime I would remove a tag with a space in the text, it would throw an error in the jquery selector. Adding these escaped quotes has fixed this bug for me.